### PR TITLE
Add config for message squelching on join

### DIFF
--- a/src/main/java/com/codenameflip/chatchannels/channels/Channel.java
+++ b/src/main/java/com/codenameflip/chatchannels/channels/Channel.java
@@ -124,6 +124,15 @@ public class Channel {
      * @param player The player who you would like to focus to this channel
      */
     public void focus(Player player) {
+        focus(player, true);
+    }
+
+    /**
+     * Forces a player to "focus" or begin talking in this channel
+     * @param player The player who you would like to focus to this channel
+     * @param notify Whether or not to notify the player of this change
+     */
+    public void focus(Player player, boolean notify) {
         ChatChannels.get().getChannels().forEach(channel -> {
             if (channel.getFocused().contains(player.getUniqueId()))
                 channel.getFocused().remove(player.getUniqueId());
@@ -131,7 +140,9 @@ public class Channel {
 
         focused.add(player.getUniqueId());
 
-        player.sendMessage(ChatColor.AQUA + "Set your chat focus to " + getColor() + ChatColor.BOLD + "[" + getName() + "]");
+        if (notify) {
+            player.sendMessage(ChatColor.AQUA + "Set your chat focus to " + getColor() + ChatColor.BOLD + "[" + getName() + "]");
+        }
     }
 
     /**
@@ -139,10 +150,21 @@ public class Channel {
      * @param player The player who you would like to view this channel
      */
     public void display(Player player) {
+        display(player, true);
+    }
+
+    /**
+     * Forces a player to view this channel
+     * @param player The player who you would like to view this channel
+     * @param notify Whether or not to notify the player of this change
+     */
+    public void display(Player player, boolean notify) {
         if (!viewing.contains(player.getUniqueId())) {
             viewing.add(player.getUniqueId());
 
-            player.sendMessage(ChatColor.GREEN + "You are now viewing " + getColor() + ChatColor.BOLD + "[" + getName() + "]");
+            if (notify) {
+                player.sendMessage(ChatColor.GREEN + "You are now viewing " + getColor() + ChatColor.BOLD + "[" + getName() + "]");
+            }
         }
     }
 

--- a/src/main/java/com/codenameflip/chatchannels/listeners/PlayerJoin.java
+++ b/src/main/java/com/codenameflip/chatchannels/listeners/PlayerJoin.java
@@ -26,7 +26,7 @@ public class PlayerJoin implements Listener {
             ChatChannels.get().getDefaultViewingChannels().forEach(channel ->
                     channel.display(
                             player,
-                            ChatChannels.get().getConfig().getBoolean("chat-settings.squelch-viewing-message-on-join")
+                            !(ChatChannels.get().getConfig().getBoolean("chat-settings.squelch-viewing-message-on-join"))
                     )
             );
         }
@@ -34,7 +34,7 @@ public class PlayerJoin implements Listener {
         if (ChatChannels.get().getFocusedChannel(player) == null) {
             ChatChannels.get().getDefaultChannel().focus(
                     player,
-                    ChatChannels.get().getConfig().getBoolean("chat-settings.squelch-focus-message-on-join")
+                    !(ChatChannels.get().getConfig().getBoolean("chat-settings.squelch-focus-message-on-join"))
             );
         }
 

--- a/src/main/java/com/codenameflip/chatchannels/listeners/PlayerJoin.java
+++ b/src/main/java/com/codenameflip/chatchannels/listeners/PlayerJoin.java
@@ -22,11 +22,21 @@ public class PlayerJoin implements Listener {
         Player player = event.getPlayer();
 
         // If a player has newly logged in, automatically focus to the default channel and force them to view the default channels
-        if (ChatChannels.get().getViewingChannels(player).size() == 0)
-            ChatChannels.get().getDefaultViewingChannels().forEach(channel -> channel.display(player));
+        if (ChatChannels.get().getViewingChannels(player).size() == 0) {
+            ChatChannels.get().getDefaultViewingChannels().forEach(channel ->
+                    channel.display(
+                            player,
+                            ChatChannels.get().getConfig().getBoolean("chat-settings.squelch-viewing-message-on-join")
+                    )
+            );
+        }
 
-        if (ChatChannels.get().getFocusedChannel(player) == null)
-            ChatChannels.get().getDefaultChannel().focus(player);
+        if (ChatChannels.get().getFocusedChannel(player) == null) {
+            ChatChannels.get().getDefaultChannel().focus(
+                    player,
+                    ChatChannels.get().getConfig().getBoolean("chat-settings.squelch-focus-message-on-join")
+            );
+        }
 
         // Check to see if a new update has been cached
         if (player.hasPermission("chatchannels.update.notify")) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,6 +31,10 @@ chat-settings:
   announce-permissions: false
   ## Do you want all chat messages to be output in console?
   log-messages: true
+  ## Do you want to turn off viewing notification message on join?
+  squelch-viewing-message-on-join: true
+  ## Do you want to turn off focus notification message on join?
+  squelch-focus-message-on-join: true
 channels:
   global:
     name: "Global"


### PR DESCRIPTION
This PR adds config options to not show the "You are now viewing" and "Set your ..." messages on join, only thereafter.